### PR TITLE
Fix admin login flow and asset paths

### DIFF
--- a/admin/change_password.php
+++ b/admin/change_password.php
@@ -2,7 +2,7 @@
 session_start();
 include_once 'includes/config.php';
 if (!isset($_SESSION['user_id'])) {
-  header("Location: {$BASE_URL}login.php");
+  header("Location: {$BASE_URL}index.php");
   exit();
 }
 ?>
@@ -14,7 +14,7 @@ if (!isset($_SESSION['user_id'])) {
   <title>Change Password – iSwift Website Admin</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="<?= $BASE_URL ?>admin/assets/style.css">
+  <link rel="stylesheet" href="<?= $BASE_URL ?>assets/style.css">
 </head>
 <body class="sidebar-layout">
 
@@ -37,6 +37,6 @@ if (!isset($_SESSION['user_id'])) {
   </form>
 </div>
 
-<script src="<?= $BASE_URL ?>admin/assets/nav.js"></script>
+<script src="<?= $BASE_URL ?>assets/nav.js"></script>
 </body>
 </html>

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -2,7 +2,7 @@
 session_start();
 include_once 'includes/config.php';
 if (!isset($_SESSION['user_id'])) {
-  header("Location: {$BASE_URL}login.php");
+  header("Location: {$BASE_URL}index.php");
   exit();
 }
 ?>
@@ -13,7 +13,7 @@ if (!isset($_SESSION['user_id'])) {
   <title>Dashboard – iSwift ERP</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="<?= $BASE_URL ?>admin/assets/style.css">
+  <link rel="stylesheet" href="<?= $BASE_URL ?>assets/style.css">
 </head>
 <body class="sidebar-layout dashboard-page">
   <?php include __DIR__ . '/includes/nav.php'; ?>
@@ -42,12 +42,12 @@ if (!isset($_SESSION['user_id'])) {
 
     <!-- Quick links (static) -->
     <section class="quick-actions" aria-label="Quick actions">
-      <a class="qa-btn" href="<?= $BASE_URL ?>admin/products/list.php">Manage Products</a>
-      <a class="qa-btn ghost" href="<?= $BASE_URL ?>admin/products/add.php">Add New Product</a>
-      <a class="qa-btn ghost" href="<?= $BASE_URL ?>admin/change_password.php">Change Password</a>
+      <a class="qa-btn" href="<?= $BASE_URL ?>products/list.php">Manage Products</a>
+      <a class="qa-btn ghost" href="<?= $BASE_URL ?>products/add.php">Add New Product</a>
+      <a class="qa-btn ghost" href="<?= $BASE_URL ?>change_password.php">Change Password</a>
     </section>
   </main>
 
-  <script src="<?= $BASE_URL ?>admin/assets/nav.js"></script>
+  <script src="<?= $BASE_URL ?>assets/nav.js"></script>
 </body>
 </html>

--- a/admin/includes/nav.php
+++ b/admin/includes/nav.php
@@ -15,27 +15,27 @@ function is_active(string $file, string $current): string {
 <aside class="sidebar" id="sidebar" role="navigation" aria-label="Admin sidebar">
   <div>
     <div class="logo">
-      <a href="<?= $BASE_URL ?>admin/dashboard.php" aria-label="iSwift Admin Home">
-        <img src="<?= $BASE_URL ?>admin/assets/iSwift_logo.png" alt="iSwift Logo">
+      <a href="<?= $BASE_URL ?>dashboard.php" aria-label="iSwift Admin Home">
+        <img src="<?= $BASE_URL ?>assets/iSwift_logo.png" alt="iSwift Logo">
       </a>
     </div>
 
     <nav class="sidebar-nav">
-      <a href="<?= $BASE_URL ?>admin/dashboard.php"
+      <a href="<?= $BASE_URL ?>dashboard.php"
          class="<?= is_active('dashboard.php', $current) ?>">Dashboard</a>
 
-      <a href="<?= $BASE_URL ?>admin/products/list.php"
+      <a href="<?= $BASE_URL ?>products/list.php"
          class="<?= is_active('list.php', $current) ?>">Products</a>
 
-      <a href="<?= $BASE_URL ?>admin/products/add.php"
+      <a href="<?= $BASE_URL ?>products/add.php"
          class="<?= is_active('add.php', $current) ?>">Add Product</a>
 
-      <a href="<?= $BASE_URL ?>admin/change_password.php"
+      <a href="<?= $BASE_URL ?>change_password.php"
          class="<?= is_active('change_password.php', $current) ?>">Change Password</a>
     </nav>
   </div>
 
   <div class="logout">
-    <a href="<?= $BASE_URL ?>admin/logout.php">Log out</a>
+    <a href="<?= $BASE_URL ?>logout.php">Log out</a>
   </div>
 </aside>

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,4 +1,13 @@
-<?php include __DIR__ . '/includes/config.php'; ?>
+<?php
+session_start();
+include __DIR__ . '/includes/config.php';
+
+// If the user is already logged in, send them to the dashboard
+if (isset($_SESSION['user_id'])) {
+    header("Location: {$BASE_URL}dashboard.php");
+    exit();
+}
+?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -7,15 +16,19 @@
   <title>Login – iSwift ERP</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <!-- Scoped login stylesheet -->
-  <link rel="stylesheet" href="<?= $BASE_URL ?>admin/assets/style.css">
+  <link rel="stylesheet" href="<?= $BASE_URL ?>assets/style.css">
 </head>
 <body class="login-page">
   <main class="auth-container">
     <section class="auth-card">
       <div class="auth-header">
-        <img class="logo" src="<?= $BASE_URL ?>admin/assets/iSwift_logo.png" alt="iSwift ERP">
+        <img class="logo" src="<?= $BASE_URL ?>assets/iSwift_logo.png" alt="iSwift ERP">
         <h1 class="title">Admin Login</h1>
         <p class="subtitle">Sign in to continue to your dashboard</p>
+        <?php if (!empty($_SESSION['error'])): ?>
+          <p class="error" style="color:#c00;"><?= htmlspecialchars($_SESSION['error']) ?></p>
+          <?php unset($_SESSION['error']); ?>
+        <?php endif; ?>
       </div>
 
       <form action="login.php" method="POST" class="auth-form" novalidate>

--- a/admin/login.php
+++ b/admin/login.php
@@ -5,13 +5,31 @@ session_start();
 require_once __DIR__ . '/../core/config.php';
 require_once __DIR__ . '/../core/db.php';
 
+// Prepare redirect base URL for admin area (works regardless of BASE_URL)
+// For /admin/login.php this resolves to '/admin/'
+$adminBase = rtrim(dirname($_SERVER['SCRIPT_NAME'] ?? '/admin/login.php'), '/') . '/';
+
+// Already logged in? Head straight to dashboard
+if (isset($_SESSION['user_id'])) {
+    header('Location: ' . $adminBase . 'dashboard.php');
+    exit;
+}
+
+// Only handle POST requests
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: ' . $adminBase . 'index.php');
+    exit;
+}
+
 // Collect POST data safely
 $email = trim($_POST['email'] ?? '');
 $password = $_POST['password'] ?? '';
 
-// Prepare redirect base URL for admin area (works regardless of BASE_URL)
-// For /admin/login.php this resolves to '/admin/'
-$adminBase = rtrim(dirname($_SERVER['SCRIPT_NAME'] ?? '/admin/login.php'), '/') . '/';
+if ($email === '' || $password === '') {
+    $_SESSION['error'] = 'Please provide both email and password.';
+    header('Location: ' . $adminBase . 'index.php');
+    exit;
+}
 
 try {
     $pdo = db();

--- a/admin/logout.php
+++ b/admin/logout.php
@@ -10,9 +10,9 @@ include __DIR__ . '/includes/config.php';
   <meta charset="UTF-8">
   <title>Logged Out – iSwift ERP</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="refresh" content="2;url=<?= $BASE_URL ?>admin/index.php">
+  <meta http-equiv="refresh" content="2;url=<?= $BASE_URL ?>index.php">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="<?= $BASE_URL ?>admin/assets/style.css">
+  <link rel="stylesheet" href="<?= $BASE_URL ?>assets/style.css">
 </head>
 <body class="logout-page">
   <main class="auth-container">
@@ -20,7 +20,7 @@ include __DIR__ . '/includes/config.php';
       <h1 class="logout-title">You’ve been logged out</h1>
       <p class="logout-sub">
         Redirecting to login page…
-        <a href="<?= $BASE_URL ?>admin/index.php">Click here</a> if not redirected.
+        <a href="<?= $BASE_URL ?>index.php">Click here</a> if not redirected.
       </p>
     </section>
   </main>

--- a/admin/products/add.php
+++ b/admin/products/add.php
@@ -220,7 +220,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <meta charset="utf-8">
   <title>Admin · Add Product</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="<?= $BASE_URL ?>admin/assets/style.css">
+  <link rel="stylesheet" href="<?= $BASE_URL ?>assets/style.css">
 </head>
 <body class="sidebar-layout">
 <?php include __DIR__ . '/../includes/nav.php'; ?>
@@ -392,7 +392,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     </div>
   </div>
 
-<script src="<?= $BASE_URL ?>admin/assets/nav.js"></script>
+<script src="<?= $BASE_URL ?>assets/nav.js"></script>
 
 <script>
 function removeClosest(btn, sel){ const el = btn.closest(sel); if(el) el.remove(); }

--- a/admin/products/edit.php
+++ b/admin/products/edit.php
@@ -338,7 +338,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <meta charset="utf-8">
     <title>Admin · Edit Product</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="<?= $BASE_URL ?>admin/assets/style.css">
+    <link rel="stylesheet" href="<?= $BASE_URL ?>assets/style.css">
 </head>
 
 <body class="sidebar-layout">
@@ -534,7 +534,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     </div>
 </div>
 
-<script src="<?= $BASE_URL ?>admin/assets/nav.js"></script>
+<script src="<?= $BASE_URL ?>assets/nav.js"></script>
 
     <script>
         function removeClosest(btn, sel) {

--- a/admin/products/list.php
+++ b/admin/products/list.php
@@ -44,7 +44,7 @@ if (!isset($pdo) || !($pdo instanceof PDO)) {
     <meta charset="utf-8">
     <title>Admin · Products</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="<?= $BASE_URL ?>admin/assets/style.css">
+    <link rel="stylesheet" href="<?= $BASE_URL ?>assets/style.css">
 </head>
 
 <body class="sidebar-layout">
@@ -221,7 +221,7 @@ if (!isset($pdo) || !($pdo instanceof PDO)) {
     </div>
 </div>
 
-<script src="<?= $BASE_URL ?>admin/assets/nav.js"></script>
+<script src="<?= $BASE_URL ?>assets/nav.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Redirect authenticated users away from login page
- Add robust login handler with request/missing data checks
- Correct admin asset paths so styles and scripts load properly

## Testing
- `php -l admin/index.php`
- `php -l admin/login.php`
- `php -l admin/dashboard.php`
- `php -l admin/includes/nav.php`
- `php -l admin/logout.php`
- `php -l admin/change_password.php`
- `php -l admin/products/add.php`
- `php -l admin/products/edit.php`
- `php -l admin/products/list.php`


------
https://chatgpt.com/codex/tasks/task_e_68b4f1862a348332baa87add42316575